### PR TITLE
Fix Transport Config Bug

### DIFF
--- a/src/applications/restapi/endpoints/notification.ts
+++ b/src/applications/restapi/endpoints/notification.ts
@@ -168,8 +168,9 @@ function readRequest(request: Request): Promise<Input> {
       smtpConfig: {
         host: metadata?.smtp.host,
         port: metadata?.smtp.port,
-        user: metadata?.smtp.username,
-        pass: metadata?.smtp.password,
+        user: metadata?.smtp?.username,
+        pass: metadata?.smtp?.password,
+        secure: metadata?.smtp?.secure,
       },
       subject: `${metadata.subject}`,
       from: `${metadata.from}`,

--- a/src/applications/restapi/endpoints/sendmail.ts
+++ b/src/applications/restapi/endpoints/sendmail.ts
@@ -97,8 +97,9 @@ function readRequest(request: Request): Promise<Input> {
         smtpConfig: {
           host: metadata?.smtp.host,
           port: metadata?.smtp.port,
-          user: metadata?.smtp.username,
-          pass: metadata?.smtp.password,
+          user: metadata?.smtp?.username,
+          pass: metadata?.smtp?.password,
+          secure: metadata?.smtp?.secure,
         },
         subject: `${metadata.subject}`,
         from: `${metadata.from}`,

--- a/src/implementations/senders.ts
+++ b/src/implementations/senders.ts
@@ -22,7 +22,15 @@ export interface SimpleSMTPConfig {
  * @returns A [[Mail]] instance as a transport agent to use send mails through.
  */
 function makeTransport(config: SimpleSMTPConfig): Mail {
-  return createTransport(encodeURI(`smtp://${config.user}:${config.pass}@${config.host}:${config.port}`));
+  return createTransport({
+    host: config.host,
+    port: config.port,
+    auth: {
+      user: config.user,
+      pass: config.pass,
+    },
+    secure: config.secure,
+  });
 }
 
 /**

--- a/src/implementations/senders.ts
+++ b/src/implementations/senders.ts
@@ -12,6 +12,7 @@ export interface SimpleSMTPConfig {
   port?: number;
   user?: string;
   pass?: string;
+  secure?: boolean;
 }
 
 /**


### PR DESCRIPTION
- feat: add secure flag to smtp configuration
- fix: use config object instead of SMTP URI for creating transports

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)



* **What is the current behavior?** (You can also link to an open issue here)



* **What is the new behavior (if this is a feature change)?**



* **Other information**:
